### PR TITLE
chore!: bump minimum noir version to 0.35.0

### DIFF
--- a/.github/NIGHTLY_CANARY_DIED.md
+++ b/.github/NIGHTLY_CANARY_DIED.md
@@ -1,6 +1,6 @@
 ---
 title: "Tests fail on latest Nargo nightly release"
-assignees: TomAFrench
+assignees: TomAFrench, kashbrti, joshua
 ---
 
 The tests on this Noir project have started failing when using the latest nightly release of the Noir compiler. This likely means that there have been breaking changes for which this project needs to be updated to take into account.

--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Run Noir tests
         run: nargo test
 
-      - name: Run formatter
-        run: nargo fmt --check
-
       - name: Alert on dead links
         uses: JasonEtco/create-an-issue@v2
         if: ${{ failure() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,27 @@ jobs:
 
       - name: Run formatter
         run: nargo fmt --check
+
+  # This is a job which depends on all test jobs and reports the overall status.
+  # This allows us to add/remove test jobs without having to update the required workflows.
+  tests-end:
+    name: Noir End
+    runs-on: ubuntu-latest
+    # We want this job to always run (even if the dependant jobs fail) as we want this job to fail rather than skipping.
+    if: ${{ always() }}
+    needs: 
+      - test
+      - format
+
+    steps:
+      - name: Report overall success
+        run: |
+          if [[ $FAIL == true ]]; then
+              exit 1
+          else
+              exit 0
+          fi
+        env:
+          # We treat any cancelled, skipped or failing jobs as a failure for the workflow as a whole.
+          FAIL: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [nightly, 0.34.0]
+        toolchain: [nightly, 0.35.0]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 0.34.0
+          toolchain: 0.35.0
 
       - name: Run formatter
         run: nargo fmt --check

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -2,6 +2,6 @@
 name = "mimc"
 type = "lib"
 authors = [""]
-compiler_version = ">=0.34.0"
+compiler_version = ">=0.35.0"
 
 [dependencies]


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR bumps the minimum version of noir for this library to be 0.35.0

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
