### PR TITLE
chore: Add Noir version query job and update test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,15 +8,36 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  MINIMUM_NOIR_VERSION: v1.0.0-beta.19
 
 jobs:
+  noir-version-list:
+    name: Query supported Noir versions
+    runs-on: ubuntu-latest
+    outputs:
+      noir_versions: ${{ steps.get_versions.outputs.versions }}
+
+    steps:
+      - name: Checkout sources
+        id: get_versions
+        run: |         
+          # gh returns the Noir releases in reverse chronological order so we keep all releases published after the minimum supported version.
+          VERSIONS=$(gh release list -R noir-lang/noir --exclude-pre-releases --json tagName -q 'map(.tagName) | index(env.MINIMUM_NOIR_VERSION) as $index | if $index then .[0:$index+1] else [env.MINIMUM_NOIR_VERSION] end')
+          echo "versions=$VERSIONS"
+          echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   test:
+    needs: [noir-version-list]
     name: Test on Nargo ${{matrix.toolchain}}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [nightly, 1.0.0-beta.19]
+        toolchain: ${{ fromJson( needs.noir-version-list.outputs.noir_versions )}}
+        include:
+          - toolchain: nightly
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -38,7 +59,7 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 1.0.0-beta.19
+          toolchain: ${{ env.MINIMUM_NOIR_VERSION }}
 
       - name: Run formatter
         run: nargo fmt --check
@@ -65,4 +86,3 @@ jobs:
         env:
           # We treat any cancelled, skipped or failing jobs as a failure for the workflow as a whole.
           FAIL: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
-


### PR DESCRIPTION
Added a job to query supported Noir versions and updated the test matrix to use these versions.

## Problem Resolved

Resolves <!-- Link to GitHub Issue -->

## Summary of Changes



## PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
